### PR TITLE
Дискорд активность

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -86,6 +86,9 @@ dependencies {
         modImplementation "ru.kelcuprum:ActionBarInfo-fabric:${rootProject.abi}+mc${project.abi_minecraft_version == null ? project.minecraft_version : project.abi_minecraft_version}"
     }
 
+    // https://mvnrepository.com/artifact/com.github.jncrmx/discord-game-sdk4j
+    modImplementation 'com.github.jncrmx:discord-game-sdk4j:0.5.5'
+    include 'com.github.jncrmx:discord-game-sdk4j:0.5.5'
 
     subprojects.each {
         implementation project(path: ":${it.name}", configuration: 'namedElements')

--- a/src/main/java/ru/kelcuprum/pplhelper/PepeLandHelper.java
+++ b/src/main/java/ru/kelcuprum/pplhelper/PepeLandHelper.java
@@ -229,8 +229,8 @@ public class PepeLandHelper implements ClientModInitializer {
             if (TabHelper.getWorld() == null || minecraft.getCurrentServer() == null || minecraft.getCurrentServer().players == null) return;
 
             String worldName = TabHelper.getWorld().title.getString();
-            int onlinePlayers = minecraft.getCurrentServer().players.online();
-            int maxPlayers = minecraft.getCurrentServer().players.max();
+            int onlinePlayers = TabHelper.getOnline();
+            int maxPlayers = TabHelper.getMaxOnline();
 
             DiscordActivityManager.updatePresence(worldName, onlinePlayers, maxPlayers);
         } catch (RuntimeException e) {

--- a/src/main/java/ru/kelcuprum/pplhelper/gui/screens/configs/ConfigScreen.java
+++ b/src/main/java/ru/kelcuprum/pplhelper/gui/screens/configs/ConfigScreen.java
@@ -79,6 +79,10 @@ public class ConfigScreen {
                 .addWidget(new HorizontalRuleBuilder(Component.translatable("pplhelper.configs.urls")))
                 .addWidget(new EditBoxBuilder(Component.translatable("pplhelper.configs.modrinth_url")).setValue("https://modrinth.com/").setConfig(PepeLandHelper.config, "MODRINTH_URL"));
 
+        builder.addWidget(new HorizontalRuleBuilder(Component.translatable("pplhelper.configs.ds")))
+                .addWidget(new EditBoxBuilder(Component.translatable("pplhelper.configs.ds.details")).setValue("Играет на Pepeland - %playersCount% / %maxPlayers%").setConfig(PepeLandHelper.config, "DS_DETAILS"))
+                .addWidget(new EditBoxBuilder(Component.translatable("pplhelper.configs.ds.state")).setValue("%worldName%").setConfig(PepeLandHelper.config, "DS_STATE"));
+
         return builder.build();
     }
 }

--- a/src/main/java/ru/kelcuprum/pplhelper/utils/DiscordActivityManager.java
+++ b/src/main/java/ru/kelcuprum/pplhelper/utils/DiscordActivityManager.java
@@ -1,0 +1,106 @@
+package ru.kelcuprum.pplhelper.utils;
+
+import de.jcm.discordgamesdk.Core;
+import de.jcm.discordgamesdk.CreateParams;
+import de.jcm.discordgamesdk.activity.Activity;
+import net.minecraft.network.chat.Component;
+import ru.kelcuprum.pplhelper.PepeLandHelper;
+
+import java.io.IOException;
+import java.time.Instant;
+
+public class DiscordActivityManager {
+    private static Core discordCore;
+    private static Activity currentActivity;
+    private static long startTime;
+    private static boolean initialized = false;
+
+    public static void initialize() {
+        try {
+            Core.initDownload();
+            Core.initDiscordNative("discord_game_sdk");
+
+            CreateParams params = new CreateParams();
+
+            // Воткни сюда свой айди или оставь айдишник моего бота
+            params.setClientID(1429038037899411558L);
+
+            params.setFlags(CreateParams.getDefaultFlags());
+
+            discordCore = new Core(params);
+            currentActivity = new Activity();
+            startTime = Instant.now().getEpochSecond();
+
+            initialized = true;
+
+            Thread callbackThread = new Thread(() -> {
+                while (initialized && discordCore != null) {
+                    try {
+                        discordCore.runCallbacks();
+                        Thread.sleep(2000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    } catch (Exception e) {
+                        System.err.println("Error in Discord callback thread: " + e.getMessage());
+                        break;
+                    }
+                }
+            }, "Discord-RPC-Callback");
+            callbackThread.setDaemon(true);
+            callbackThread.start();
+
+        } catch (Exception e) {
+            System.err.println("Failed to initialize Discord RPC: " + e.getMessage());
+        }
+    }
+
+    public static void updatePresence(String worldName, int playerCount, int maxPlayers) {
+        if (!initialized || discordCore == null) return;
+
+        try {
+            String details = (Boolean.parseBoolean(PepeLandHelper.config.getString("DS_DETAILS")) ?
+                    PepeLandHelper.config.getString("DS_DETAILS") : Component.translatable("pplhelper.configs.ds.details.default").getString())
+                    .replace("%playersCount%", String.valueOf(playerCount))
+                    .replace("%maxPlayers%", String.valueOf(maxPlayers));
+
+            String state = (Boolean.parseBoolean(PepeLandHelper.config.getString("DS_STATE")) ?
+                    PepeLandHelper.config.getString("DS_STATE") : Component.translatable("pplhelper.configs.ds.state.default").getString())
+                    .replace("%worldName%", worldName);
+
+            currentActivity.setDetails(details);
+            currentActivity.setState(state);
+            currentActivity.timestamps().setStart(Instant.ofEpochSecond(startTime));
+
+            currentActivity.assets().setLargeImage("logo");
+            currentActivity.assets().setLargeText("Pepeland");
+
+            discordCore.activityManager().updateActivity(currentActivity);
+        } catch (Exception e) {
+            System.err.println("Error updating Discord presence: " + e.getMessage());
+        }
+    }
+
+    public static void clearPresence() {
+        if (!initialized || discordCore == null) return;
+
+        try {
+            discordCore.activityManager().clearActivity();
+        } catch (Exception e) {
+            System.err.println("Error clearing Discord presence: " + e.getMessage());
+        }
+    }
+
+    public static void shutDown() {
+        initialized = false;
+        if (discordCore != null) {
+            try {
+                clearPresence();
+                discordCore.close();
+                discordCore = null;
+            } catch (Exception e) {
+                System.err.println("Error shutting down Discord RPC: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/pplhelper/lang/en_us.json
+++ b/src/main/resources/assets/pplhelper/lang/en_us.json
@@ -73,6 +73,13 @@
   "pplhelper.configs.pack_updates.modrinth.api_warn": "Временно отключено, так как API PPL Helper недоступен",
   "pplhelper.configs.pack_updates.only_emote.citresewn_not_installed": "У вас не установлен CIT Resewn, поэтому мод будет загружать только эмоуты",
 
+  "pplhelper.configs.ds": "Дискорд активность",
+  "pplhelper.configs.ds.details": "Название",
+  "pplhelper.configs.ds.state": "Информация",
+
+  "pplhelper.configs.ds.details.default": "Играет на Pepeland - %playersCount% / %maxPlayers%",
+  "pplhelper.configs.ds.state.default": "%worldName%",
+
   "pplhelper.chat_filters": "Фильтры чата",
 
   "pplhelper.chat_filters.global": "Отключить глобальный чат",


### PR DESCRIPTION
Реализовал функционал дискорд активности с отображением мира в котором на данный момент находиться игрок.
В ``DiscordActivityManager`` - ``params.setClientID(1429038037899411558L);`` нужно подкинуть свой айди вместо тестового.
``ppl-helper-test`` - имя тестового бота.
<img width="450" height="190" alt="activ" src="https://github.com/user-attachments/assets/f73a34b0-acfa-4706-b351-7e588ce51cf1" />
Простите если реализовал не совсем прямо, у меня немного опыта в модинге, но очень хочется реализовать подобную идею.
